### PR TITLE
Fixed link that lead to 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Chorus, Flanger, Sampler, Stereo Delay, and Synth for AudioKit, by Shane Dunne.
 
 ## Documentation
 
-Detailed documentation is provided on [AudioKit's Website](http://audiokit.io/Packages/DunneAudioKit/).
+Detailed documentation is provided on [AudioKit's Website](https://audiokit.io/DunneAudioKit/).
 
 ## API Reference
 


### PR DESCRIPTION
Just to try the toolchain a little fix on the Readme, fixing a broken link. 